### PR TITLE
Add comprehensive unit tests - Closes #30

### DIFF
--- a/tests/BookRec.Application.Tests/BookService.cs
+++ b/tests/BookRec.Application.Tests/BookService.cs
@@ -1,0 +1,192 @@
+using Moq;
+using BookRec.Application.Books.Dtos;
+using BookRec.Application.Books.Services;
+using BookRec.Domain.BookModel;
+
+namespace BookRec.Application.Tests;
+
+public class BookServiceTests
+{
+    private readonly Mock<IBookRepository> _mockRepo;
+    private readonly BookService _service;
+
+    public BookServiceTests()
+    {
+        _mockRepo = new Mock<IBookRepository>();
+        _service = new BookService(_mockRepo.Object);
+    }
+
+    private Book CreateValidBook(Guid? id = null) => new(
+        id ?? Guid.NewGuid(),
+        "Test Book",
+        "Test Author",
+        "Test Description",
+        new List<string> { "Fiction" },
+        DateTime.UtcNow
+    );
+
+    [Fact]
+    public async Task GetByIdAsync_BookExists_ReturnsBookDto()
+    {
+        var book = CreateValidBook();
+        _mockRepo.Setup(r => r.GetByIdAsync(book.Id)).ReturnsAsync(book);
+
+        var result = await _service.GetByIdAsync(book.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(book.Id, result.Id);
+        Assert.Equal("Test Book", result.Title);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_BookNotFound_ReturnsNull()
+    {
+        _mockRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync((Book?)null);
+
+        var result = await _service.GetByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByTitleAsync_BookExists_ReturnsBookDto()
+    {
+        var book = CreateValidBook();
+        _mockRepo.Setup(r => r.GetByTitleAsync("Test Book")).ReturnsAsync(book);
+
+        var result = await _service.GetByTitleAsync("Test Book");
+
+        Assert.NotNull(result);
+        Assert.Equal("Test Book", result.Title);
+    }
+
+    [Fact]
+    public async Task GetByTitleAsync_BookNotFound_ReturnsNull()
+    {
+        _mockRepo.Setup(r => r.GetByTitleAsync(It.IsAny<string>())).ReturnsAsync((Book?)null);
+
+        var result = await _service.GetByTitleAsync("Nonexistent");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByAuthor_BooksExist_ReturnsBookDtos()
+    {
+        var books = new List<Book> { CreateValidBook(), CreateValidBook() };
+        _mockRepo.Setup(r => r.GetByAuthorAsync("Test Author")).ReturnsAsync(books);
+
+        var result = await _service.GetByAuthorAsync("Test Author");
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetByAuthor_NoBooksFound_ReturnsEmptyList()
+    {
+        _mockRepo.Setup(r => r.GetByAuthorAsync(It.IsAny<string>())).ReturnsAsync(new List<Book>());
+
+        var result = await _service.GetByAuthorAsync("Unknown Author");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByGenre_BooksExist_ReturnsBookDtos()
+    {
+        var books = new List<Book> { CreateValidBook(), CreateValidBook() };
+        _mockRepo.Setup(r => r.GetByGenreAsync("Fiction")).ReturnsAsync(books);
+
+        var result = await _service.GetByGenreAsync("Fiction");
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetByGenre_NoBooksFound_ReturnsEmptyList()
+    {
+        _mockRepo.Setup(r => r.GetByGenreAsync(It.IsAny<string>())).ReturnsAsync(new List<Book>());
+
+        var result = await _service.GetByGenreAsync("Unknown Genre");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_BooksExist_ReturnsAllBookDtos()
+    {
+        var books = new List<Book> { CreateValidBook(), CreateValidBook(), CreateValidBook() };
+        _mockRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(books);
+
+        var result = await _service.GetAllAsync();
+
+        Assert.Equal(3, result.Count);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_NoBooksExist_ReturnsEmptyList()
+    {
+        _mockRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(new List<Book>());
+
+        var result = await _service.GetAllAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddBook_ValidDto_ReturnsNewGuid()
+    {
+        var dto = new CreateBookDto("Title", "Author", "Description", new List<string> { "Fiction" }, DateTime.UtcNow);
+        _mockRepo.Setup(r => r.AddAsync(It.IsAny<Book>())).Returns(Task.CompletedTask);
+
+        var result = await _service.AddBook(dto);
+
+        Assert.NotEqual(Guid.Empty, result);
+        _mockRepo.Verify(r => r.AddAsync(It.IsAny<Book>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateBook_BookExists_UpdatesAndReturnsId()
+    {
+        var book = CreateValidBook();
+        var updateDto = new UpdateBookDto("New Title", null, null, null, null, DateTime.UtcNow);
+        _mockRepo.Setup(r => r.GetByIdAsync(book.Id)).ReturnsAsync(book);
+        _mockRepo.Setup(r => r.AddAsync(It.IsAny<Book>())).Returns(Task.CompletedTask);
+
+        var result = await _service.UpdateBook(updateDto, book.Id);
+
+        Assert.Equal(book.Id, result);
+    }
+
+    [Fact]
+    public async Task UpdateBook_BookNotFound_ThrowsException()
+    {
+        var updateDto = new UpdateBookDto("New Title", null, null, null, null, DateTime.UtcNow);
+        _mockRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync((Book?)null);
+
+        await Assert.ThrowsAsync<Exception>(() => _service.UpdateBook(updateDto, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public async Task DeleteBook_BookExists_CallsDeleteAsync()
+    {
+        var book = CreateValidBook();
+        _mockRepo.Setup(r => r.GetByIdAsync(book.Id)).ReturnsAsync(book);
+        _mockRepo.Setup(r => r.DeleteAsync(book.Id)).Returns(Task.CompletedTask);
+
+        await _service.DeleteBook(book.Id);
+
+        _mockRepo.Verify(r => r.DeleteAsync(book.Id), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteBook_BookNotFound_DoesNotCallDelete()
+    {
+        _mockRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync((Book?)null);
+
+        await _service.DeleteBook(Guid.NewGuid());
+
+        _mockRepo.Verify(r => r.DeleteAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+}

--- a/tests/BookRec.Application.Tests/RecommendationServiceTests.cs
+++ b/tests/BookRec.Application.Tests/RecommendationServiceTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using BookRec.Application.Books.Services;
+using BookRec.Application.Users.Interface;
+using BookRec.Domain.BookModel;
+using BookRec.Application.Books.Dtos;
+using BookRec.Domain.UserModel;
+
+namespace BookRec.Application.Tests
+{
+    public class RecommendationServiceTests
+    {
+        [Fact]
+        public async Task RecommendBooksForUserAsync_ExcludesReadBooks_AndMatchesGenres()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var readBookId = Guid.NewGuid();
+
+            var mockUserService = new Mock<IUserService>();
+            mockUserService.Setup(s => s.GetUserPreferredGenresAsync(userId))
+                .ReturnsAsync(new List<string> { "Fantasy", "Sci-Fi" });
+            mockUserService.Setup(s => s.GetUserReadBookIdsAsync(userId))
+                .ReturnsAsync(new List<Guid> { readBookId });
+
+            var book1 = new Book(Guid.NewGuid(), "A", "Author", "Desc", new[] { "Fantasy" }, DateTime.UtcNow.AddYears(-1));
+            var book2 = new Book(readBookId, "B", "Author2", "Desc2", new[] { "Sci-Fi" }, DateTime.UtcNow.AddYears(-2));
+            var book3 = new Book(Guid.NewGuid(), "C", "Author3", "Desc3", new[] { "Mystery" }, DateTime.UtcNow);
+
+            var mockBookRepo = new Mock<BookRec.Domain.BookModel.IBookRepository>();
+            mockBookRepo.Setup(r => r.GetByGenreAsync("Fantasy")).ReturnsAsync(new List<Book> { book1 });
+            mockBookRepo.Setup(r => r.GetByGenreAsync("Sci-Fi")).ReturnsAsync(new List<Book> { book2 });
+
+            var service = new RecommendationService(mockUserService.Object, mockBookRepo.Object);
+
+            // Act
+            var results = await service.RecommendBooksForUserAsync(userId, 10);
+
+            // Assert
+            Assert.NotNull(results);
+            var ids = results.Select(r => r.Id).ToList();
+            Assert.Contains(book1.Id, ids);
+            Assert.DoesNotContain(book2.Id, ids); // read book excluded
+            Assert.DoesNotContain(book3.Id, ids); // different genre
+        }
+    }
+}

--- a/tests/BookRec.Application.Tests/UserService.cs
+++ b/tests/BookRec.Application.Tests/UserService.cs
@@ -1,0 +1,174 @@
+using Moq;
+using BookRec.Application.Users.Dtos;
+using BookRec.Application.Users.Services;
+using BookRec.Domain.UserModel;
+
+namespace BookRec.Application.Tests;
+
+public class UserServiceTests
+{
+    private readonly Mock<IUserRepository> _mockRepo;
+    private readonly UserService _service;
+
+    public UserServiceTests()
+    {
+        _mockRepo = new Mock<IUserRepository>();
+        _service = new UserService(_mockRepo.Object);
+    }
+
+    private User CreateValidUser(Guid? id = null) => new(
+        id ?? Guid.NewGuid(),
+        "testuser",
+        "John",
+        "Doe",
+        "john@test.com",
+        new List<string> { "Fiction" },
+        DateTime.UtcNow
+    );
+
+    [Fact]
+    public async Task GetByIdAsync_UserExists_ReturnsUserDto()
+    {
+        var user = CreateValidUser();
+        _mockRepo.Setup(r => r.GetByIdAsync(user.Id)).ReturnsAsync(user);
+
+        var result = await _service.GetByIdAsync(user.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal(user.Id, result.Id);
+        Assert.Equal("testuser", result.Username);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_UserNotFound_ReturnsNull()
+    {
+        _mockRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync((User?)null);
+
+        var result = await _service.GetByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByEmailAsync_UserExists_ReturnsUserDto()
+    {
+        var user = CreateValidUser();
+        _mockRepo.Setup(r => r.GetByEmailAsync("john@test.com")).ReturnsAsync(user);
+
+        var result = await _service.GetByEmailAsync("john@test.com");
+
+        Assert.NotNull(result);
+        Assert.Equal("john@test.com", result.Email);
+    }
+
+    [Fact]
+    public async Task GetByEmailAsync_UserNotFound_ReturnsNull()
+    {
+        _mockRepo.Setup(r => r.GetByEmailAsync(It.IsAny<string>())).ReturnsAsync((User?)null);
+
+        var result = await _service.GetByEmailAsync("notfound@test.com");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByUserAsync_UserExists_ReturnsUserDto()
+    {
+        var user = CreateValidUser();
+        _mockRepo.Setup(r => r.GetByUserAsync("testuser")).ReturnsAsync(user);
+
+        var result = await _service.GetByUserAsync("testuser");
+
+        Assert.NotNull(result);
+        Assert.Equal("testuser", result.Username);
+    }
+
+    [Fact]
+    public async Task GetByUserAsync_UserNotFound_ReturnsNull()
+    {
+        _mockRepo.Setup(r => r.GetByUserAsync(It.IsAny<string>())).ReturnsAsync((User?)null);
+
+        var result = await _service.GetByUserAsync("notfound");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetUserPreferredGenresAsync_UserExists_ReturnsGenres()
+    {
+        var user = CreateValidUser();
+        _mockRepo.Setup(r => r.GetByIdAsync(user.Id)).ReturnsAsync(user);
+
+        var result = await _service.GetUserPreferredGenresAsync(user.Id);
+
+        Assert.Single(result);
+        Assert.Contains("Fiction", result);
+    }
+
+    [Fact]
+    public async Task GetUserPreferredGenresAsync_UserNotFound_ReturnsEmptyList()
+    {
+        _mockRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync((User?)null);
+
+        var result = await _service.GetUserPreferredGenresAsync(Guid.NewGuid());
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddUser_ValidDto_ReturnsNewGuid()
+    {
+        var dto = new CreateUserDto("newuser1", "Jane", "Doe", "jane@test.com", new List<string> { "Mystery" }, DateTime.UtcNow);
+        _mockRepo.Setup(r => r.AddAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+
+        var result = await _service.AddUser(dto);
+
+        Assert.NotEqual(Guid.Empty, result);
+        _mockRepo.Verify(r => r.AddAsync(It.IsAny<User>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateUser_UserExists_UpdatesAndReturnsId()
+    {
+        var user = CreateValidUser();
+        var updateDto = new UpdateUserDto("newusername", null, null, null, null, DateTime.UtcNow);
+        _mockRepo.Setup(r => r.GetByIdAsync(user.Id)).ReturnsAsync(user);
+        _mockRepo.Setup(r => r.UpdateAsync(It.IsAny<User>())).Returns(Task.CompletedTask);
+
+        var result = await _service.UpdateUser(updateDto, user.Id);
+
+        Assert.Equal(user.Id, result);
+        _mockRepo.Verify(r => r.UpdateAsync(It.IsAny<User>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateUser_UserNotFound_ThrowsException()
+    {
+        var updateDto = new UpdateUserDto("newusername", null, null, null, null, DateTime.UtcNow);
+        _mockRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync((User?)null);
+
+        await Assert.ThrowsAsync<Exception>(() => _service.UpdateUser(updateDto, Guid.NewGuid()));
+    }
+
+    [Fact]
+    public async Task DeleteUser_UserExists_CallsDeleteAsync()
+    {
+        var user = CreateValidUser();
+        _mockRepo.Setup(r => r.GetByIdAsync(user.Id)).ReturnsAsync(user);
+        _mockRepo.Setup(r => r.DeleteAsync(user.Id)).Returns(Task.CompletedTask);
+
+        await _service.DeleteUser(user.Id);
+
+        _mockRepo.Verify(r => r.DeleteAsync(user.Id), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteUser_UserNotFound_DoesNotCallDelete()
+    {
+        _mockRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync((User?)null);
+
+        await _service.DeleteUser(Guid.NewGuid());
+
+        _mockRepo.Verify(r => r.DeleteAsync(It.IsAny<Guid>()), Times.Never);
+    }
+}

--- a/tests/BookRec.Application.Tests/UserServiceTests.cs
+++ b/tests/BookRec.Application.Tests/UserServiceTests.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using BookRec.Application.Users.Services;
+using BookRec.Domain.UserModel;
+
+namespace BookRec.Application.Tests
+{
+    public class UserServiceReadTests
+    {
+        [Fact]
+        public async Task MarkBookAsReadAsync_AddsBookAndCallsUpdate()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var bookId = Guid.NewGuid();
+
+            var user = new User(userId, "tester", "First", "Last", "a@b.com", new[] { "Fantasy" }, DateTime.UtcNow);
+
+            var mockRepo = new Mock<BookRec.Domain.UserModel.IUserRepository>();
+            mockRepo.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(user);
+            mockRepo.Setup(r => r.UpdateAsync(It.IsAny<User>())).Returns(Task.CompletedTask).Verifiable();
+
+            var service = new UserService(mockRepo.Object);
+
+            // Act
+            await service.MarkBookAsReadAsync(userId, bookId);
+
+            // Assert
+            mockRepo.Verify(r => r.UpdateAsync(It.Is<User>(u => u.ReadBooks.Contains(bookId))), Times.Once);
+        }
+
+        [Fact]
+        public async Task UnmarkBookAsReadAsync_RemovesBookAndCallsUpdate()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var bookId = Guid.NewGuid();
+
+            var user = new User(userId, "tester2", "First", "Last", "b@b.com", new[] { "Sci-Fi" }, DateTime.UtcNow);
+            user.updateReadBooks(new[] { bookId });
+
+            var mockRepo = new Mock<BookRec.Domain.UserModel.IUserRepository>();
+            mockRepo.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(user);
+            mockRepo.Setup(r => r.UpdateAsync(It.IsAny<User>())).Returns(Task.CompletedTask).Verifiable();
+
+            var service = new UserService(mockRepo.Object);
+
+            // Act
+            await service.UnmarkBookAsReadAsync(userId, bookId);
+
+            // Assert
+            mockRepo.Verify(r => r.UpdateAsync(It.Is<User>(u => !u.ReadBooks.Contains(bookId))), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetUserReadBookIdsAsync_ReturnsReadIds()
+        {
+            // Arrange
+            var userId = Guid.NewGuid();
+            var book1 = Guid.NewGuid();
+            var book2 = Guid.NewGuid();
+
+            var user = new User(userId, "tester3", "First", "Last", "c@b.com", new[] { "Mystery" }, DateTime.UtcNow);
+            user.updateReadBooks(new[] { book1, book2 });
+
+            var mockRepo = new Mock<BookRec.Domain.UserModel.IUserRepository>();
+            mockRepo.Setup(r => r.GetByIdAsync(userId)).ReturnsAsync(user);
+
+            var service = new UserService(mockRepo.Object);
+
+            // Act
+            var result = await service.GetUserReadBookIdsAsync(userId);
+
+            // Assert
+            Assert.Contains(book1, result);
+            Assert.Contains(book2, result);
+            Assert.Equal(2, result.Count);
+        }
+    }
+}

--- a/tests/BookRec.Domain.Tests/BookTests.cs
+++ b/tests/BookRec.Domain.Tests/BookTests.cs
@@ -1,0 +1,137 @@
+using BookRec.Domain.BookModel;
+
+namespace BookRec.Domain.Tests;
+
+public class BookTests
+{
+    private Book CreateValidBook() => new(
+        Guid.NewGuid(),
+        "Test Book",
+        "Test Author",
+        "Test Description",
+        new List<string> { "Fiction" },
+        DateTime.UtcNow
+    );
+
+    [Fact]
+    public void Constructor_ValidData_CreatesBook()
+    {
+        var book = CreateValidBook();
+
+        Assert.Equal("Test Book", book.Title);
+        Assert.Equal("Test Author", book.Author);
+        Assert.Equal("Test Description", book.Description);
+        Assert.Single(book.Genres);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_InvalidTitle_Throws(string? title)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Book(Guid.NewGuid(), title!, "Author", "Description", new List<string> { "Fiction" }, DateTime.UtcNow));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_InvalidAuthor_Throws(string? author)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Book(Guid.NewGuid(), "Title", author!, "Description", new List<string> { "Fiction" }, DateTime.UtcNow));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_InvalidDescription_Throws(string? description)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Book(Guid.NewGuid(), "Title", "Author", description!, new List<string> { "Fiction" }, DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void Constructor_DescriptionTooLong_Throws()
+    {
+        var longDescription = new string('a', 801);
+
+        Assert.Throws<ArgumentException>(() =>
+            new Book(Guid.NewGuid(), "Title", "Author", longDescription, new List<string> { "Fiction" }, DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void Constructor_NullGenres_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Book(Guid.NewGuid(), "Title", "Author", "Description", null!, DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void Constructor_EmptyGenres_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new Book(Guid.NewGuid(), "Title", "Author", "Description", new List<string>(), DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void AddGenre_ValidGenre_AddsToList()
+    {
+        var book = CreateValidBook();
+
+        book.addGenre("Mystery");
+
+        Assert.Equal(2, book.Genres.Count);
+        Assert.Contains("Mystery", book.Genres);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddGenre_InvalidGenre_Throws(string? genre)
+    {
+        var book = CreateValidBook();
+
+        Assert.Throws<ArgumentException>(() => book.addGenre(genre!));
+    }
+
+    [Fact]
+    public void AddGenre_DuplicateGenre_Throws()
+    {
+        var book = CreateValidBook();
+
+        Assert.Throws<ArgumentException>(() => book.addGenre("Fiction"));
+    }
+
+    [Fact]
+    public void AddGenre_DuplicateDifferentCase_Throws()
+    {
+        var book = CreateValidBook();
+
+        Assert.Throws<ArgumentException>(() => book.addGenre("FICTION"));
+    }
+
+    [Fact]
+    public void UpdateGenres_ValidGenres_ReplacesAll()
+    {
+        var book = CreateValidBook();
+
+        book.updateGenres(new List<string> { "Horror", "Thriller" });
+
+        Assert.Equal(2, book.Genres.Count);
+        Assert.DoesNotContain("Fiction", book.Genres);
+    }
+
+    [Fact]
+    public void UpdateGenres_NullOrEmpty_Throws()
+    {
+        var book = CreateValidBook();
+
+        Assert.Throws<ArgumentException>(() => book.updateGenres(null!));
+        Assert.Throws<ArgumentException>(() => book.updateGenres(new List<string>()));
+    }
+}

--- a/tests/BookRec.Domain.Tests/UserTests.cs
+++ b/tests/BookRec.Domain.Tests/UserTests.cs
@@ -1,0 +1,191 @@
+using BookRec.Domain.UserModel;
+
+namespace BookRec.Domain.Tests;
+
+public class UserTests
+{
+    private User CreateValidUser() => new(
+        Guid.NewGuid(),
+        "testuser",
+        "John",
+        "Doe",
+        "john@test.com",
+        new List<string> { "Fiction" },
+        DateTime.UtcNow
+    );
+
+    [Fact]
+    public void Constructor_ValidData_CreatesUser()
+    {
+        var user = CreateValidUser();
+
+        Assert.Equal("testuser", user.Username);
+        Assert.Equal("John", user.FirstName);
+        Assert.Equal("Doe", user.LastName);
+        Assert.Equal("john@test.com", user.Email);
+        Assert.Single(user.PreferredGenres);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SetUsername_InvalidUsername_Throws(string? username)
+    {
+        var user = CreateValidUser();
+
+        Assert.Throws<ArgumentException>(() => user.setUserName(username!));
+    }
+
+    [Theory]
+    [InlineData("test")]      // Too short (4 chars)
+    [InlineData("abcdefghijklmnopqrstuvwxyz12345")]  // Too long (31 chars)
+    public void SetUsername_InvalidLength_Throws(string username)
+    {
+        var user = CreateValidUser();
+
+        Assert.Throws<ArgumentException>(() => user.setUserName(username));
+    }
+
+    [Fact]
+    public void SetUsername_ValidUsername_Updates()
+    {
+        var user = CreateValidUser();
+
+        user.setUserName("newuser123");
+
+        Assert.Equal("newuser123", user.Username);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SetFirstName_InvalidFirstName_Throws(string? firstName)
+    {
+        var user = CreateValidUser();
+
+        Assert.Throws<ArgumentException>(() => user.setFirstName(firstName!));
+    }
+
+    [Fact]
+    public void SetFirstName_ValidFirstName_Updates()
+    {
+        var user = CreateValidUser();
+
+        user.setFirstName("Jane");
+
+        Assert.Equal("Jane", user.FirstName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SetLastName_InvalidLastName_Throws(string? lastName)
+    {
+        var user = CreateValidUser();
+
+        Assert.Throws<ArgumentException>(() => user.setLastName(lastName!));
+    }
+
+    [Fact]
+    public void SetLastName_ValidLastName_Updates()
+    {
+        var user = CreateValidUser();
+
+        user.setLastName("Smith");
+
+        Assert.Equal("Smith", user.LastName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void UpdateEmail_InvalidEmail_Throws(string? email)
+    {
+        var user = CreateValidUser();
+
+        Assert.Throws<ArgumentException>(() => user.updateEmail(email!));
+    }
+
+    [Theory]
+    [InlineData("notanemail")]
+    [InlineData("missing@")]
+    [InlineData("@nodomain.com")]
+    public void UpdateEmail_InvalidFormat_Throws(string email)
+    {
+        var user = CreateValidUser();
+
+        Assert.Throws<ArgumentException>(() => user.updateEmail(email));
+    }
+
+    [Fact]
+    public void UpdateEmail_ValidEmail_Updates()
+    {
+        var user = CreateValidUser();
+
+        user.updateEmail("new@email.com");
+
+        Assert.Equal("new@email.com", user.Email);
+    }
+
+    [Fact]
+    public void AddPreferredGenre_ValidGenre_AddsToList()
+    {
+        var user = CreateValidUser();
+
+        user.addPreferredGenre("Mystery");
+
+        Assert.Equal(2, user.PreferredGenres.Count);
+        Assert.Contains("Mystery", user.PreferredGenres);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void AddPreferredGenre_InvalidGenre_Throws(string? genre)
+    {
+        var user = CreateValidUser();
+
+        Assert.Throws<ArgumentException>(() => user.addPreferredGenre(genre!));
+    }
+
+    [Fact]
+    public void AddPreferredGenre_DuplicateGenre_Throws()
+    {
+        var user = CreateValidUser();
+
+        Assert.Throws<ArgumentException>(() => user.addPreferredGenre("Fiction"));
+    }
+
+    [Fact]
+    public void AddPreferredGenre_DuplicateDifferentCase_Throws()
+    {
+        var user = CreateValidUser();
+
+        Assert.Throws<ArgumentException>(() => user.addPreferredGenre("FICTION"));
+    }
+
+    [Fact]
+    public void UpdatePreferredGenres_ValidGenres_ReplacesAll()
+    {
+        var user = CreateValidUser();
+
+        user.updatePreferredGenres(new List<string> { "Horror", "Thriller" });
+
+        Assert.Equal(2, user.PreferredGenres.Count);
+        Assert.DoesNotContain("Fiction", user.PreferredGenres);
+    }
+
+    [Fact]
+    public void UpdatePreferredGenres_NullOrEmpty_Throws()
+    {
+        var user = CreateValidUser();
+
+        Assert.Throws<ArgumentException>(() => user.updatePreferredGenres(null!));
+        Assert.Throws<ArgumentException>(() => user.updatePreferredGenres(new List<string>()));
+    }
+}

--- a/tests/BookRec.Infrastructure.Tests/AppDbContextTests.cs
+++ b/tests/BookRec.Infrastructure.Tests/AppDbContextTests.cs
@@ -1,0 +1,105 @@
+using BookRec.Infrastructure.Dbos;
+using BookRec.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BookRec.Infrastructure.Tests.Persistence;
+
+public class AppDbContextTests : IDisposable
+{
+    private readonly AppDbContext _context;
+
+    public AppDbContextTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new AppDbContext(options);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public void Books_DbSet_ShouldNotBeNull()
+    {
+        Assert.NotNull(_context.Books);
+    }
+
+    [Fact]
+    public void Users_DbSet_ShouldNotBeNull()
+    {
+        Assert.NotNull(_context.Users);
+    }
+
+    [Fact]
+    public async Task CanAddAndRetrieveBook()
+    {
+        var book = new BookDBO
+        {
+            Id = Guid.NewGuid(),
+            Title = "Test Book",
+            Author = "Author",
+            Description = "Desc",
+            Genre = "Fiction",
+            PublishDate = DateTime.UtcNow
+        };
+
+        _context.Books.Add(book);
+        await _context.SaveChangesAsync();
+
+        var result = await _context.Books.FirstOrDefaultAsync(b => b.Id == book.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal("Test Book", result.Title);
+    }
+
+    [Fact]
+    public async Task CanAddAndRetrieveUser()
+    {
+        var user = new UserDBO
+        {
+            Id = Guid.NewGuid(),
+            Username = "testuser",
+            FirstName = "Test",
+            LastName = "User",
+            Email = "test@example.com",
+            PreferredGenres = "Fiction"
+        };
+
+        _context.Users.Add(user);
+        await _context.SaveChangesAsync();
+
+        var result = await _context.Users.FirstOrDefaultAsync(u => u.Id == user.Id);
+
+        Assert.NotNull(result);
+        Assert.Equal("testuser", result.Username);
+    }
+
+    [Fact]
+    public async Task CanUpdateBook()
+    {
+        var book = new BookDBO { Id = Guid.NewGuid(), Title = "Original" };
+        _context.Books.Add(book);
+        await _context.SaveChangesAsync();
+
+        book.Title = "Updated";
+        await _context.SaveChangesAsync();
+
+        var result = await _context.Books.FirstOrDefaultAsync(b => b.Id == book.Id);
+        Assert.Equal("Updated", result!.Title);
+    }
+
+    [Fact]
+    public async Task CanDeleteBook()
+    {
+        var book = new BookDBO { Id = Guid.NewGuid(), Title = "ToDelete" };
+        _context.Books.Add(book);
+        await _context.SaveChangesAsync();
+
+        _context.Books.Remove(book);
+        await _context.SaveChangesAsync();
+
+        var result = await _context.Books.FirstOrDefaultAsync(b => b.Id == book.Id);
+        Assert.Null(result);
+    }
+}

--- a/tests/BookRec.Infrastructure.Tests/ConfigTests/BookConfigTests.cs
+++ b/tests/BookRec.Infrastructure.Tests/ConfigTests/BookConfigTests.cs
@@ -1,0 +1,95 @@
+using BookRec.Infrastructure.Dbos;
+using BookRec.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BookRec.Infrastructure.Tests.Persistence;
+
+public class BookConfigurationTests : IDisposable
+{
+    private readonly AppDbContext _context;
+
+    public BookConfigurationTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new AppDbContext(options);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public void BookDBO_ShouldHavePrimaryKey()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(BookDBO));
+        var primaryKey = entityType?.FindPrimaryKey();
+
+        Assert.NotNull(primaryKey);
+        Assert.Equal("Id", primaryKey.Properties[0].Name);
+    }
+
+    [Fact]
+    public void BookDBO_Title_ShouldBeRequired()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(BookDBO));
+        var property = entityType?.FindProperty("Title");
+
+        Assert.NotNull(property);
+        Assert.False(property.IsNullable);
+    }
+
+    [Fact]
+    public void BookDBO_Title_ShouldHaveMaxLength200()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(BookDBO));
+        var property = entityType?.FindProperty("Title");
+
+        Assert.Equal(200, property?.GetMaxLength());
+    }
+
+    [Fact]
+    public void BookDBO_Author_ShouldHaveMaxLength200()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(BookDBO));
+        var property = entityType?.FindProperty("Author");
+
+        Assert.Equal(200, property?.GetMaxLength());
+    }
+
+    [Fact]
+    public void BookDBO_Description_ShouldHaveMaxLength800()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(BookDBO));
+        var property = entityType?.FindProperty("Description");
+
+        Assert.Equal(800, property?.GetMaxLength());
+    }
+
+    [Fact]
+    public void BookDBO_ShouldHaveIndexOnTitle()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(BookDBO));
+        var indexes = entityType?.GetIndexes().ToList();
+
+        Assert.Contains(indexes!, i => i.Properties.Any(p => p.Name == "Title"));
+    }
+
+    [Fact]
+    public void BookDBO_ShouldHaveIndexOnAuthor()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(BookDBO));
+        var indexes = entityType?.GetIndexes().ToList();
+
+        Assert.Contains(indexes!, i => i.Properties.Any(p => p.Name == "Author"));
+    }
+
+    [Fact]
+    public void BookDBO_ShouldHaveIndexOnGenre()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(BookDBO));
+        var indexes = entityType?.GetIndexes().ToList();
+
+        Assert.Contains(indexes!, i => i.Properties.Any(p => p.Name == "Genre"));
+    }
+}

--- a/tests/BookRec.Infrastructure.Tests/ConfigTests/UserConfigTests.cs
+++ b/tests/BookRec.Infrastructure.Tests/ConfigTests/UserConfigTests.cs
@@ -1,0 +1,99 @@
+using BookRec.Infrastructure.Dbos;
+using BookRec.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BookRec.Infrastructure.Tests.Persistence;
+
+public class UserConfigurationTests : IDisposable
+{
+    private readonly AppDbContext _context;
+
+    public UserConfigurationTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new AppDbContext(options);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public void UserDBO_ShouldHavePrimaryKey()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(UserDBO));
+        var primaryKey = entityType?.FindPrimaryKey();
+
+        Assert.NotNull(primaryKey);
+        Assert.Equal("Id", primaryKey.Properties[0].Name);
+    }
+
+    [Fact]
+    public void UserDBO_Username_ShouldBeRequired()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(UserDBO));
+        var property = entityType?.FindProperty("Username");
+
+        Assert.NotNull(property);
+        Assert.False(property.IsNullable);
+    }
+
+    [Fact]
+    public void UserDBO_Username_ShouldHaveMaxLength100()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(UserDBO));
+        var property = entityType?.FindProperty("Username");
+
+        Assert.Equal(100, property?.GetMaxLength());
+    }
+
+    [Fact]
+    public void UserDBO_Email_ShouldHaveMaxLength100()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(UserDBO));
+        var property = entityType?.FindProperty("Email");
+
+        Assert.Equal(100, property?.GetMaxLength());
+    }
+
+    [Fact]
+    public void UserDBO_FirstName_ShouldHaveMaxLength100()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(UserDBO));
+        var property = entityType?.FindProperty("FirstName");
+
+        Assert.Equal(100, property?.GetMaxLength());
+    }
+
+    [Fact]
+    public void UserDBO_LastName_ShouldHaveMaxLength100()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(UserDBO));
+        var property = entityType?.FindProperty("LastName");
+
+        Assert.Equal(100, property?.GetMaxLength());
+    }
+
+    [Fact]
+    public void UserDBO_ShouldHaveUniqueIndexOnEmail()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(UserDBO));
+        var indexes = entityType?.GetIndexes().ToList();
+        var emailIndex = indexes?.FirstOrDefault(i => i.Properties.Any(p => p.Name == "Email"));
+
+        Assert.NotNull(emailIndex);
+        Assert.True(emailIndex.IsUnique);
+    }
+
+    [Fact]
+    public void UserDBO_ShouldHaveUniqueIndexOnUsername()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(UserDBO));
+        var indexes = entityType?.GetIndexes().ToList();
+        var usernameIndex = indexes?.FirstOrDefault(i => i.Properties.Any(p => p.Name == "Username"));
+
+        Assert.NotNull(usernameIndex);
+        Assert.True(usernameIndex.IsUnique);
+    }
+}

--- a/tests/BookRec.Infrastructure.Tests/DboTests/Bookdbotests.cs
+++ b/tests/BookRec.Infrastructure.Tests/DboTests/Bookdbotests.cs
@@ -1,0 +1,65 @@
+using BookRec.Infrastructure.Dbos;
+using Xunit;
+
+namespace BookRec.Infrastructure.Tests.Dbos;
+
+public class BookDBOTests
+{
+    [Fact]
+    public void BookDBO_ShouldInitializeWithDefaultValues()
+    {
+        var book = new BookDBO();
+
+        Assert.Equal(Guid.Empty, book.Id);
+        Assert.Equal(string.Empty, book.Title);
+        Assert.Equal(string.Empty, book.Author);
+        Assert.Equal(string.Empty, book.Description);
+        Assert.Equal(string.Empty, book.Genre);
+    }
+
+    [Fact]
+    public void BookDBO_ShouldSetAndGetProperties()
+    {
+        var id = Guid.NewGuid();
+        var publishDate = new DateTime(2023, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+
+        var book = new BookDBO
+        {
+            Id = id,
+            Title = "Test Title",
+            Author = "Test Author",
+            Description = "Test Description",
+            Genre = "Fiction",
+            PublishDate = publishDate
+        };
+
+        Assert.Equal(id, book.Id);
+        Assert.Equal("Test Title", book.Title);
+        Assert.Equal("Test Author", book.Author);
+        Assert.Equal("Test Description", book.Description);
+        Assert.Equal("Fiction", book.Genre);
+        Assert.Equal(publishDate, book.PublishDate);
+    }
+
+    [Fact]
+    public void BookDBO_CreatedAt_ShouldDefaultToUtcNow()
+    {
+        var before = DateTime.UtcNow;
+        var book = new BookDBO();
+        var after = DateTime.UtcNow;
+
+        Assert.True(book.CreatedAt >= before);
+        Assert.True(book.CreatedAt <= after);
+    }
+
+    [Fact]
+    public void BookDBO_UpdatedAt_ShouldDefaultToUtcNow()
+    {
+        var before = DateTime.UtcNow;
+        var book = new BookDBO();
+        var after = DateTime.UtcNow;
+
+        Assert.True(book.UpdatedAt >= before);
+        Assert.True(book.UpdatedAt <= after);
+    }
+}

--- a/tests/BookRec.Infrastructure.Tests/DboTests/Userdbotests.cs
+++ b/tests/BookRec.Infrastructure.Tests/DboTests/Userdbotests.cs
@@ -1,0 +1,65 @@
+using BookRec.Infrastructure.Dbos;
+using Xunit;
+
+namespace BookRec.Infrastructure.Tests.Dbos;
+
+public class UserDBOTests
+{
+    [Fact]
+    public void UserDBO_ShouldInitializeWithDefaultValues()
+    {
+        var user = new UserDBO();
+
+        Assert.Equal(Guid.Empty, user.Id);
+        Assert.Equal(string.Empty, user.Username);
+        Assert.Equal(string.Empty, user.FirstName);
+        Assert.Equal(string.Empty, user.LastName);
+        Assert.Equal(string.Empty, user.Email);
+        Assert.Equal(string.Empty, user.PreferredGenres);
+    }
+
+    [Fact]
+    public void UserDBO_ShouldSetAndGetProperties()
+    {
+        var id = Guid.NewGuid();
+
+        var user = new UserDBO
+        {
+            Id = id,
+            Username = "johndoe",
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john@example.com",
+            PreferredGenres = "Fiction,Mystery"
+        };
+
+        Assert.Equal(id, user.Id);
+        Assert.Equal("johndoe", user.Username);
+        Assert.Equal("John", user.FirstName);
+        Assert.Equal("Doe", user.LastName);
+        Assert.Equal("john@example.com", user.Email);
+        Assert.Equal("Fiction,Mystery", user.PreferredGenres);
+    }
+
+    [Fact]
+    public void UserDBO_createdAt_ShouldDefaultToUtcNow()
+    {
+        var before = DateTime.UtcNow;
+        var user = new UserDBO();
+        var after = DateTime.UtcNow;
+
+        Assert.True(user.createdAt >= before);
+        Assert.True(user.createdAt <= after);
+    }
+
+    [Fact]
+    public void UserDBO_updatedAt_ShouldDefaultToUtcNow()
+    {
+        var before = DateTime.UtcNow;
+        var user = new UserDBO();
+        var after = DateTime.UtcNow;
+
+        Assert.True(user.updatedAt >= before);
+        Assert.True(user.updatedAt <= after);
+    }
+}

--- a/tests/BookRec.Infrastructure.Tests/MapperTests/BookMapperTests.cs
+++ b/tests/BookRec.Infrastructure.Tests/MapperTests/BookMapperTests.cs
@@ -1,0 +1,114 @@
+using BookRec.Domain.BookModel;
+using BookRec.Infrastructure.Dbos;
+using BookRec.Infrastructure.Mappers;
+using Xunit;
+
+namespace BookRec.Infrastructure.Tests.Mappers;
+
+public class BookMapperTests
+{
+    [Fact]
+    public void ToDomain_ShouldMapAllProperties()
+    {
+        var id = Guid.NewGuid();
+        var publishDate = new DateTime(2023, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+        var dbo = new BookDBO
+        {
+            Id = id,
+            Title = "Test Book",
+            Author = "Test Author",
+            Description = "Test Description",
+            Genre = "Fiction,Mystery",
+            PublishDate = publishDate
+        };
+
+        var result = BookMapper.ToDomain(dbo);
+
+        Assert.Equal(id, result.Id);
+        Assert.Equal("Test Book", result.Title);
+        Assert.Equal("Test Author", result.Author);
+        Assert.Equal("Test Description", result.Description);
+        Assert.Equal(2, result.Genres.Count);
+        Assert.Contains("Fiction", result.Genres);
+        Assert.Contains("Mystery", result.Genres);
+        Assert.Equal(publishDate, result.PublishDate);
+    }
+
+    [Fact]
+    public void ToDomain_ShouldHandleSingleGenre()
+    {
+        var dbo = new BookDBO
+        {
+            Id = Guid.NewGuid(),
+            Title = "Test",
+            Author = "Author",
+            Description = "Description",
+            Genre = "Fiction"
+        };
+
+        var result = BookMapper.ToDomain(dbo);
+
+        Assert.Single(result.Genres);
+        Assert.Contains("Fiction", result.Genres);
+    }
+
+    [Fact]
+    public void ToDBO_ShouldMapAllProperties()
+    {
+        var id = Guid.NewGuid();
+        var publishDate = new DateTime(2023, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+        var book = new Book(id, "Test Book", "Test Author", "Test Description", 
+            new List<string> { "Fiction", "Mystery" }, publishDate);
+
+        var result = BookMapper.ToDBO(book);
+
+        Assert.Equal(id, result.Id);
+        Assert.Equal("Test Book", result.Title);
+        Assert.Equal("Test Author", result.Author);
+        Assert.Equal("Test Description", result.Description);
+        Assert.Equal("Fiction,Mystery", result.Genre);
+        Assert.Equal(publishDate, result.PublishDate);
+    }
+
+    [Fact]
+    public void ToDBO_ShouldSetTimestamps()
+    {
+        var before = DateTime.UtcNow;
+        var book = new Book(Guid.NewGuid(), "Title", "Author", "Description", 
+            new List<string> { "Genre" }, DateTime.UtcNow);
+
+        var result = BookMapper.ToDBO(book);
+        var after = DateTime.UtcNow;
+
+        Assert.True(result.CreatedAt >= before && result.CreatedAt <= after);
+        Assert.True(result.UpdatedAt >= before && result.UpdatedAt <= after);
+    }
+
+    [Fact]
+    public void ToDomainList_ShouldMapAllItems()
+    {
+        var dbos = new List<BookDBO>
+        {
+            new BookDBO { Id = Guid.NewGuid(), Title = "Book 1", Author = "A", Description = "D", Genre = "Fiction" },
+            new BookDBO { Id = Guid.NewGuid(), Title = "Book 2", Author = "A", Description = "D", Genre = "Mystery" },
+            new BookDBO { Id = Guid.NewGuid(), Title = "Book 3", Author = "A", Description = "D", Genre = "Romance" }
+        };
+
+        var result = BookMapper.ToDomainList(dbos);
+
+        Assert.Equal(3, result.Count);
+        Assert.Equal("Book 1", result[0].Title);
+        Assert.Equal("Book 2", result[1].Title);
+        Assert.Equal("Book 3", result[2].Title);
+    }
+
+    [Fact]
+    public void ToDomainList_ShouldReturnEmptyList_WhenEmpty()
+    {
+        var dbos = new List<BookDBO>();
+
+        var result = BookMapper.ToDomainList(dbos);
+
+        Assert.Empty(result);
+    }
+}

--- a/tests/BookRec.Infrastructure.Tests/MapperTests/UserMapperTests.cs
+++ b/tests/BookRec.Infrastructure.Tests/MapperTests/UserMapperTests.cs
@@ -1,0 +1,112 @@
+using BookRec.Domain.UserModel;
+using BookRec.Infrastructure.Dbos;
+using BookRec.Infrastructure.Mappers;
+using Xunit;
+
+namespace BookRec.Infrastructure.Tests.Mappers;
+
+public class UserMapperTests
+{
+    [Fact]
+    public void ToDomain_ShouldMapAllProperties()
+    {
+        var id = Guid.NewGuid();
+        var dbo = new UserDBO
+        {
+            Id = id,
+            Username = "johndoe123",
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john@example.com",
+            PreferredGenres = "Fiction,Mystery",
+            createdAt = DateTime.UtcNow
+        };
+
+        var result = UserMapper.ToDomain(dbo);
+
+        Assert.Equal(id, result.Id);
+        Assert.Equal("johndoe123", result.Username);
+        Assert.Equal("John", result.FirstName);
+        Assert.Equal("Doe", result.LastName);
+        Assert.Equal("john@example.com", result.Email);
+        Assert.Equal(2, result.PreferredGenres.Count);
+        Assert.Contains("Fiction", result.PreferredGenres);
+        Assert.Contains("Mystery", result.PreferredGenres);
+    }
+
+    [Fact]
+    public void ToDomain_ShouldHandleSingleGenre()
+    {
+        var dbo = new UserDBO 
+        { 
+            Id = Guid.NewGuid(),
+            Username = "testuser1",
+            FirstName = "Test",
+            LastName = "User",
+            Email = "test@example.com",
+            PreferredGenres = "Fiction" 
+        };
+
+        var result = UserMapper.ToDomain(dbo);
+
+        Assert.Single(result.PreferredGenres);
+        Assert.Contains("Fiction", result.PreferredGenres);
+    }
+
+    [Fact]
+    public void ToDBO_ShouldMapAllProperties()
+    {
+        var id = Guid.NewGuid();
+        var user = new User(id, "johndoe123", "John", "Doe", "john@example.com", 
+            new List<string> { "Fiction", "Mystery" }, DateTime.UtcNow);
+
+        var result = UserMapper.ToDBO(user);
+
+        Assert.Equal(id, result.Id);
+        Assert.Equal("johndoe123", result.Username);
+        Assert.Equal("John", result.FirstName);
+        Assert.Equal("Doe", result.LastName);
+        Assert.Equal("john@example.com", result.Email);
+        Assert.Equal("Fiction,Mystery", result.PreferredGenres);
+    }
+
+    [Fact]
+    public void ToDBO_ShouldSetTimestamps()
+    {
+        var before = DateTime.UtcNow;
+        var user = new User(Guid.NewGuid(), "testuser1", "First", "Last", "email@test.com", 
+            new List<string> { "Fiction" }, DateTime.UtcNow);
+
+        var result = UserMapper.ToDBO(user);
+        var after = DateTime.UtcNow;
+
+        Assert.True(result.createdAt >= before && result.createdAt <= after);
+        Assert.True(result.updatedAt >= before && result.updatedAt <= after);
+    }
+
+    [Fact]
+    public void ToDomainList_ShouldMapAllItems()
+    {
+        var dbos = new List<UserDBO>
+        {
+            new UserDBO { Id = Guid.NewGuid(), Username = "userone11", FirstName = "User", LastName = "One", Email = "one@test.com", PreferredGenres = "Fiction" },
+            new UserDBO { Id = Guid.NewGuid(), Username = "usertwo22", FirstName = "User", LastName = "Two", Email = "two@test.com", PreferredGenres = "Mystery" }
+        };
+
+        var result = UserMapper.ToDomainList(dbos);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("userone11", result[0].Username);
+        Assert.Equal("usertwo22", result[1].Username);
+    }
+
+    [Fact]
+    public void ToDomainList_ShouldReturnEmptyList_WhenEmpty()
+    {
+        var dbos = new List<UserDBO>();
+
+        var result = UserMapper.ToDomainList(dbos);
+
+        Assert.Empty(result);
+    }
+}

--- a/tests/BookRec.Infrastructure.Tests/RepositoryTests/BookRepositoryTests.cs
+++ b/tests/BookRec.Infrastructure.Tests/RepositoryTests/BookRepositoryTests.cs
@@ -1,0 +1,197 @@
+using BookRec.Domain.BookModel;
+using BookRec.Infrastructure.Dbos;
+using BookRec.Infrastructure.Persistence;
+using BookRec.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BookRec.Infrastructure.Tests.Repositories;
+
+public class BookRepositoryTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly BookRepository _repository;
+
+    public BookRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new AppDbContext(options);
+        _repository = new BookRepository(_context);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsBook_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        _context.Books.Add(new BookDBO { Id = id, Title = "Test", Author = "A", Description = "D", Genre = "Fiction" });
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByIdAsync(id);
+
+        Assert.NotNull(result);
+        Assert.Equal("Test", result.Title);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByTitleAsync_ReturnsBook_WhenExists()
+    {
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Title = "UniqueTitle", Author = "A", Description = "D", Genre = "Fiction" });
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByTitleAsync("UniqueTitle");
+
+        Assert.NotNull(result);
+        Assert.Equal("UniqueTitle", result.Title);
+    }
+
+    [Fact]
+    public async Task GetByTitleAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByTitleAsync("NonExistent");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByAuthorAsync_ReturnsBooks_WhenExists()
+    {
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Author = "Author1", Title = "Book1", Description = "D", Genre = "Fiction" });
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Author = "Author1", Title = "Book2", Description = "D", Genre = "Fiction" });
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Author = "Author2", Title = "Book3", Description = "D", Genre = "Fiction" });
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByAuthorAsync("Author1");
+
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public async Task GetByAuthorAsync_ReturnsEmpty_WhenNotExists()
+    {
+        var result = await _repository.GetByAuthorAsync("Unknown");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetByGenreAsync_ReturnsBooks_WhenGenreMatches()
+    {
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Genre = "Fiction", Title = "Book1", Author = "A", Description = "D" });
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Genre = "Mystery", Title = "Book2", Author = "A", Description = "D" });
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Genre = "Romance", Title = "Book3", Author = "A", Description = "D" });
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByGenreAsync("Fiction");
+
+        Assert.Single(result);
+        Assert.Equal("Book1", result[0].Title);
+    }
+
+    [Fact]
+    public async Task GetByGenreAsync_ReturnsBooks_WhenGenreIsInList()
+    {
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Genre = "Fiction,Mystery", Title = "Book1", Author = "A", Description = "D" });
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Genre = "Romance", Title = "Book2", Author = "A", Description = "D" });
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByGenreAsync("Mystery");
+
+        Assert.Single(result);
+        Assert.Equal("Book1", result[0].Title);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllBooks_OrderedByTitle()
+    {
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Title = "Zebra", Author = "A", Description = "D", Genre = "Fiction" });
+        _context.Books.Add(new BookDBO { Id = Guid.NewGuid(), Title = "Apple", Author = "A", Description = "D", Genre = "Fiction" });
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetAllAsync();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Apple", result[0].Title);
+        Assert.Equal("Zebra", result[1].Title);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsEmpty_WhenNoBooks()
+    {
+        var result = await _repository.GetAllAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddAsync_AddsBook()
+    {
+        var book = new Book(Guid.NewGuid(), "New Book", "Author", "Description", 
+            new List<string> { "Fiction" }, DateTime.UtcNow);
+
+        await _repository.AddAsync(book);
+
+        var result = await _context.Books.FirstOrDefaultAsync(b => b.Id == book.Id);
+        Assert.NotNull(result);
+        Assert.Equal("New Book", result.Title);
+        Assert.Equal("Fiction", result.Genre);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_UpdatesBook_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        _context.Books.Add(new BookDBO { Id = id, Title = "Original", Author = "A", Description = "D", Genre = "Fiction" });
+        await _context.SaveChangesAsync();
+
+        var updated = new Book(id, "Updated", "Author", "Description", 
+            new List<string> { "Mystery", "Thriller" }, DateTime.UtcNow);
+        await _repository.UpdateAsync(updated);
+
+        var result = await _context.Books.FirstOrDefaultAsync(b => b.Id == id);
+        Assert.Equal("Updated", result!.Title);
+        Assert.Equal("Mystery,Thriller", result.Genre);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_DoesNothing_WhenNotExists()
+    {
+        var book = new Book(Guid.NewGuid(), "NotExists", "Author", "Description", 
+            new List<string> { "Fiction" }, DateTime.UtcNow);
+
+        await _repository.UpdateAsync(book); // Should not throw
+
+        Assert.Empty(await _context.Books.ToListAsync());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesBook_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        _context.Books.Add(new BookDBO { Id = id, Title = "ToDelete", Author = "A", Description = "D", Genre = "Fiction" });
+        await _context.SaveChangesAsync();
+
+        await _repository.DeleteAsync(id);
+
+        Assert.Null(await _context.Books.FirstOrDefaultAsync(b => b.Id == id));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_DoesNothing_WhenNotExists()
+    {
+        await _repository.DeleteAsync(Guid.NewGuid()); // Should not throw
+
+        Assert.Empty(await _context.Books.ToListAsync());
+    }
+}

--- a/tests/BookRec.Infrastructure.Tests/RepositoryTests/UserRepositoryTests.cs
+++ b/tests/BookRec.Infrastructure.Tests/RepositoryTests/UserRepositoryTests.cs
@@ -1,0 +1,211 @@
+using BookRec.Domain.UserModel;
+using BookRec.Infrastructure.Dbos;
+using BookRec.Infrastructure.Persistence;
+using BookRec.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace BookRec.Infrastructure.Tests.Repositories;
+
+public class UserRepositoryTests : IDisposable
+{
+    private readonly AppDbContext _context;
+    private readonly UserRepository _repository;
+
+    public UserRepositoryTests()
+    {
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _context = new AppDbContext(options);
+        _repository = new UserRepository(_context);
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    // Helper to create valid UserDBO
+    private UserDBO CreateValidUserDBO(Guid? id = null, string? username = null, string? email = null)
+    {
+        return new UserDBO
+        {
+            Id = id ?? Guid.NewGuid(),
+            Username = username ?? "testuser1",
+            FirstName = "Test",
+            LastName = "User",
+            Email = email ?? $"{Guid.NewGuid()}@test.com",
+            PreferredGenres = "Fiction"
+        };
+    }
+
+    // Helper to create valid User
+    private User CreateValidUser(Guid? id = null, string? username = null, string? email = null)
+    {
+        return new User(
+            id ?? Guid.NewGuid(),
+            username ?? "testuser1",
+            "Test",
+            "User",
+            email ?? $"{Guid.NewGuid()}@test.com",
+            new List<string> { "Fiction" },
+            DateTime.UtcNow
+        );
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsUser_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        _context.Users.Add(CreateValidUserDBO(id: id, username: "findme123"));
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByIdAsync(id);
+
+        Assert.NotNull(result);
+        Assert.Equal("findme123", result.Username);
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByIdAsync(Guid.NewGuid());
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByEmailAsync_ReturnsUser_WhenExists()
+    {
+        var email = "findme@example.com";
+        _context.Users.Add(CreateValidUserDBO(email: email));
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByEmailAsync(email);
+
+        Assert.NotNull(result);
+        Assert.Equal(email, result.Email);
+    }
+
+    [Fact]
+    public async Task GetByEmailAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByEmailAsync("notfound@example.com");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetByUserAsync_ReturnsUser_WhenExists()
+    {
+        _context.Users.Add(CreateValidUserDBO(username: "uniqueuser1"));
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetByUserAsync("uniqueuser1");
+
+        Assert.NotNull(result);
+        Assert.Equal("uniqueuser1", result.Username);
+    }
+
+    [Fact]
+    public async Task GetByUserAsync_ReturnsNull_WhenNotExists()
+    {
+        var result = await _repository.GetByUserAsync("notfound1");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsAllUsers_OrderedById()
+    {
+        var id1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
+        var id2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
+        _context.Users.Add(CreateValidUserDBO(id: id2, username: "usertwo22", email: "two@test.com"));
+        _context.Users.Add(CreateValidUserDBO(id: id1, username: "userone11", email: "one@test.com"));
+        await _context.SaveChangesAsync();
+
+        var result = await _repository.GetAllAsync();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(id1, result[0].Id);
+        Assert.Equal(id2, result[1].Id);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsEmpty_WhenNoUsers()
+    {
+        var result = await _repository.GetAllAsync();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task AddAsync_AddsUser()
+    {
+        var user = CreateValidUser(username: "newuser123", email: "new@example.com");
+
+        await _repository.AddAsync(user);
+
+        var result = await _context.Users.FirstOrDefaultAsync(u => u.Id == user.Id);
+        Assert.NotNull(result);
+        Assert.Equal("newuser123", result.Username);
+    }
+
+    [Fact]
+    public async Task AddAsync_SetsCreatedAtTimestamp()
+    {
+        var before = DateTime.UtcNow;
+        var user = CreateValidUser();
+
+        await _repository.AddAsync(user);
+        var after = DateTime.UtcNow;
+
+        var result = await _context.Users.FirstOrDefaultAsync(u => u.Id == user.Id);
+        Assert.True(result!.createdAt >= before && result.createdAt <= after);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_UpdatesUser_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        _context.Users.Add(CreateValidUserDBO(id: id, username: "original1", email: "orig@test.com"));
+        await _context.SaveChangesAsync();
+
+        var updated = new User(id, "updated123", "Updated", "User", "updated@test.com", 
+            new List<string> { "Mystery" }, DateTime.UtcNow);
+        await _repository.UpdateAsync(updated);
+
+        var result = await _context.Users.FirstOrDefaultAsync(u => u.Id == id);
+        Assert.Equal("updated123", result!.Username);
+        Assert.Equal("updated@test.com", result.Email);
+        Assert.Equal("Mystery", result.PreferredGenres);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_DoesNothing_WhenNotExists()
+    {
+        var user = CreateValidUser();
+
+        await _repository.UpdateAsync(user); // Should not throw
+
+        Assert.Empty(await _context.Users.ToListAsync());
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesUser_WhenExists()
+    {
+        var id = Guid.NewGuid();
+        _context.Users.Add(CreateValidUserDBO(id: id));
+        await _context.SaveChangesAsync();
+
+        await _repository.DeleteAsync(id);
+
+        Assert.Null(await _context.Users.FirstOrDefaultAsync(u => u.Id == id));
+    }
+
+    [Fact]
+    public async Task DeleteAsync_DoesNothing_WhenNotExists()
+    {
+        await _repository.DeleteAsync(Guid.NewGuid()); // Should not throw
+
+        Assert.Empty(await _context.Users.ToListAsync());
+    }
+}


### PR DESCRIPTION
Closes #30

Added 154 unit tests covering:
- BookService (CRUD operations)
- UserService (CRUD operations) 
- RecommendationService (book recommendations)
- Repository tests
- Domain model tests

All tests passing ✅